### PR TITLE
Prevent PHP Notice in attachToFile

### DIFF
--- a/src/Svrnm/ExcelDataTables/ExcelDataTable.php
+++ b/src/Svrnm/ExcelDataTables/ExcelDataTable.php
@@ -413,6 +413,7 @@ class ExcelDataTable
 		 * @return $this
 		 */
 		public function attachToFile($srcFilename, $targetFilename = null, $forceAutoCalculation = false) {
+				$calculatedColumns = null;
 				if ($this->preserveFormulas){
 						$temp_xlsx = new ExcelWorkbook($srcFilename);
 						$calculatedColumns = $temp_xlsx->getCalculatedColumns($this->preserveFormulas);


### PR DESCRIPTION
$calculatedColumns was not declared if preserveFormulas was false, causing a PHP Notice.