### PR TITLE
ExcelWorkbook::count() type int

### DIFF
--- a/src/Svrnm/ExcelDataTables/ExcelWorkbook.php
+++ b/src/Svrnm/ExcelDataTables/ExcelWorkbook.php
@@ -144,7 +144,7 @@ class ExcelWorkbook implements \Countable
 		 *
 		 * @return int
 		 */
-		public function count() {
+		public function count(): int {
 				$sheets = $this->getWorkbook()->getElementsByTagName('sheet');
 				return $sheets->length;
 


### PR DESCRIPTION
Fix for 
Return type of Svrnm\ExcelDataTables\ExcelWorkbook::count() should either be compatible with Countable::count()