### PR TITLE
Fix config path in laravel projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use composer to add this repository to your dependencies:
 ```
 
 If you use the [Laravel framework](https://laravel.io/) you can additionally add
-the `ServiceProvider` to your `app/config.php`:
+the `ServiceProvider` to your `config/app.php`:
 
 ```PHP
 ...


### PR DESCRIPTION
The readme states that the service providers can be configured in app/config.php.  Although the correct path to add service providers in php is config/app.php